### PR TITLE
Remove deprecated "bottle :unneeded"

### DIFF
--- a/ocr.rb
+++ b/ocr.rb
@@ -4,8 +4,6 @@ class Ocr < Formula
   url "https://files.littlebird.com.au/macOCR-0.0.2.tar.gz"
   sha256 "bd1d955212cde93f8bfb657dd56a0ed3d724a30980e19172bc8832b5cdb279b8"
 
-  bottle :unneeded
-
   def install
     bin.install "ocr"
   end


### PR DESCRIPTION
Ref: https://github.com/schappim/macOCR/issues/20